### PR TITLE
Improved pause reports by placing the word pause first, 

### DIFF
--- a/Includes/Global.Context.ahk
+++ b/Includes/Global.Context.ahk
@@ -9,9 +9,9 @@
 ^+#P:: {
     ReaHotkey.TogglePause()
     If A_IsSuspended = 1
-    AccessibilityOverlay.Speak("ReaHotkey paused")
+    AccessibilityOverlay.Speak("Paused ReaHotkey")
     Else
-    AccessibilityOverlay.Speak("ReaHotkey unpaused")
+    AccessibilityOverlay.Speak("ReaHotkey ready")
 }
 
 ^+#Q:: {


### PR DESCRIPTION
users will hear the state slightly sooner. I also made the unpaused message match what the script says when first run, because unpaused seemed like weird terminology.