### PR TITLE
Basic support for Serum 2 and Diva synthesizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.5] - 2025-03-18
 
+### Added
+
+-   Added basic support for Serum 2 synthesizer by Xfer Records
+-   Added basic support for Diva synthesizer by u-HE
+
 ### Changed
 
 -   Improved Zampler reset behavior

--- a/Includes/Overlay.Definitions.ahk
+++ b/Includes/Overlay.Definitions.ahk
@@ -10,11 +10,13 @@ Standalone.DefaultOverlay.AddStaticText("No overlay defined")
 Standalone.ChooserOverlay := AccessibilityOverlay()
 Standalone.ChooserOverlay.AddCustomButton("Choose overlay",,, ActivateChooser).SetHotkey("!C", "Alt+C")
 
+#Include Overlays/Diva.ahk
 #Include Overlays/Dubler2.ahk
 #Include Overlays/Engine2.ahk
 #Include Overlays/FabFilter.ahk
 #Include Overlays/Kontakt7.ahk
 #Include Overlays/Kontakt8.ahk
 #Include Overlays/KompleteKontrol.ahk
+#Include Overlays/Serum2.ahk
 #Include Overlays/Sforzando.ahk
 #Include Overlays/Zampler.ahk

--- a/Includes/Overlays/Diva.ahk
+++ b/Includes/Overlays/Diva.ahk
@@ -1,0 +1,18 @@
+#Requires AutoHotkey v2.0
+
+Class Diva {
+
+    Static __New() {
+        Plugin.Register("Diva", "^com.u-he.Diva.vst.window1$", ObjBindMethod(this, "CreateOverlay"), True)
+    }
+
+    Static CreateOverlay(PluginInstance) {
+        Ol := AccessibilityOverlay()
+        Ol.AddHotspotButton("Previous Preset", 458, 24, CompensatePluginCoordinates,, CompensatePluginCoordinates)
+        Ol.AddOCRButton("Presets Menu, currently loaded", "Presets Menu, preset name not detected", "TesseractBest", 503, 30, 697, 45,,, CompensatePluginCoordinates,, CompensatePluginCoordinates)
+        Ol.AddHotspotButton("Next Preset", 738, 24, CompensatePluginCoordinates,, CompensatePluginCoordinates)
+        Ol.AddHotspotButton("u-HE Logo Menu", 1038, 24, CompensatePluginCoordinates,, CompensatePluginCoordinates)
+        PluginInstance.Overlay.Label := "Serum 2"
+        PluginInstance.Overlay.ChildControls := Array(Ol)
+    }
+}

--- a/Includes/Overlays/Serum2.ahk
+++ b/Includes/Overlays/Serum2.ahk
@@ -1,0 +1,19 @@
+#Requires AutoHotkey v2.0
+
+Class Serum2 {
+
+    Static __New() {
+        Plugin.Register("serum2", "^VSTGUI[0-9A-F]+$", ObjBindMethod(this, "CreateOverlay"), True)
+    }
+
+    Static CreateOverlay(PluginInstance) {
+        Ol := AccessibilityOverlay()
+        Ol.AddHotspotButton("Save Preset As...", 518, 4, CompensatePluginCoordinates,, CompensatePluginCoordinates)
+        Ol.AddOCRButton("Presets Menu, currently loaded", "Presets Menu, preset name not detected", "TesseractBest", 540, 13, 608, 23,,, CompensatePluginCoordinates,, CompensatePluginCoordinates)
+        Ol.AddHotspotButton("Previous Preset", 938, 4, CompensatePluginCoordinates,, CompensatePluginCoordinates)
+        Ol.AddHotspotButton("Next Preset", 968, 4, CompensatePluginCoordinates,, CompensatePluginCoordinates)
+        Ol.AddHotspotButton("Main Menu", 1058, 4, CompensatePluginCoordinates,, CompensatePluginCoordinates)
+        PluginInstance.Overlay.Label := "Serum 2"
+        PluginInstance.Overlay.ChildControls := Array(Ol)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ The following list contains the gist of what ReaHotkey has to offer. There may b
 * Makes it possible to load instruments, set polyphony and pitchbend range in Plogue sforzando.
   - Works inside REAPER, Ableton Live 12 and in the standalone version of sforzando.
 * Makes it possible to use the Zampler plug-in by Synapse Audio in REAPER and Ableton Live 12.
+* Adds basic support for u-HE Diva and Xfer Records Serum 2 synthesizers inside REAPER and Ableton Live 12.
+  - Supported preset browsing and accessing vendor menu in Serum and Diva.
+  - Serum version 2 or later is required, because this support won't work properly in Serum 1.X.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following list contains the gist of what ReaHotkey has to offer. There may b
   - Supported preset browsing and accessing vendor menu in Serum and Diva.
   - Serum version 2 or later is required, because this support won't work properly in Serum 1.X.
 
+
 ## Getting Started
 
 Just extract the downloaded archive and run one of the ReaHotkey executables depending on your OS architecture - 'ReaHotkey_x64.exe' if you're on a 64-bit version of Windows and 'ReaHotkey_x86.exe' if your build of Windows is 32-bit. If you than launch one of the supported plug-ins or applications, you will be able to interact with it simiilarly to how you would interact with any accessible application, like moving Between controls with Tab and Shift+Tab, switching tabs with the left or right arrows and so on. In case you want to use ReaHotkey together with one of the supported VST plug-ins in REAPER or Ableton, you can press the F6 key to move the focus inside the given plug-in's user interface. Note that for REAPER this is standard behavior - even without ReaHotkey being active.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following list contains the gist of what ReaHotkey has to offer. There may b
 * Makes it possible to load instruments, set polyphony and pitchbend range in Plogue sforzando.
   - Works inside REAPER, Ableton Live 12 and in the standalone version of sforzando.
 * Makes it possible to use the Zampler plug-in by Synapse Audio in REAPER and Ableton Live 12.
-* Adds basic support for u-HE Diva and Xfer Records Serum 2 synthesizers inside REAPER and Ableton Live 12.
+* Adds basic support for Xfer Records Serum 2 and u-HE Diva synthesizers inside REAPER and Ableton Live 12.
   - Supported preset browsing and accessing vendor menu in Serum and Diva.
   - Serum version 2 or later is required, because this support won't work properly in Serum 1.X.
 


### PR DESCRIPTION
I have implemented basic support for Diva and Serum 2 synthesizers into ReaHotkey. Here are important notes:
* Although Serum 2 overlay will also run with Serum 1, only Serum 2 is properly supported. I was unable to detect which version of Serum is running to prevent overlay from running with Serum 1, so I've stated clearly in ReadMe that Serum 2 is required.
* I have tested both overlays in both Reaper and Ableton Live 12 environments, and I've confirmed that they work properly.
* Diva's window control class is constant, while Serum's will change. I've implemented proper Regex in Serum overlay so that it works properly across window control class changes. BTW, both Serum 1 and Serum 2 have the same form of window control class, and therefore I was unable to differentiate version 2 from version 1.
* I was using OCR Button control for preset popup menus, so that Tesseract OCR will read the name of currently loaded preset in both Serum and Diva.
* I wanted to add hotkeys as well, for example Alt+P for Preset menu, but they keep getting passed to Reaper. Never mind, I can do it later once I get more familiar with ReaHotkey's internal code.
